### PR TITLE
Add missing `return` to `git_push_origin` function

### DIFF
--- a/bin/git_push_origin.py
+++ b/bin/git_push_origin.py
@@ -11,6 +11,7 @@ def run(force):
     current_branch = git_current_branch.get()
     if current_branch == "master":
         sys.stdout.write("Current branch is `master`. This is not allowed. Quitting....\n")
+        return
 
     result = git.push(current_branch, force)
     if result.stdout:


### PR DESCRIPTION
## tl;dr
- The function did not exit after detecting the current branch was `master`